### PR TITLE
feat: implemented TODO, added tests and justfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+package-lock.json
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 package-lock.json
 node_modules
+cargo_output.txt
+npm_output.txt

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,47 @@
+binary := "target/debug/depx"
+
+# Default task: run all tests
+default: test
+
+# Build the project
+build:
+    cargo build
+
+# Run all tests
+test: test-cargo test-npm
+    @echo "All tests passed!"
+
+# Run Cargo duplicate tests
+test-cargo: build
+    @echo "Running Cargo duplicate tests..."
+    @CLICOLOR_FORCE=1 {{binary}} duplicates test_suite/cargo_duplicates --verbose
+    @{{binary}} duplicates test_suite/cargo_duplicates --verbose > cargo_output.txt
+    @grep -q "serde (2 versions)" cargo_output.txt
+    @grep -q "v1.0.152 (2 transitive)" cargo_output.txt
+    @grep -q "v1.0.150 (4 transitive)" cargo_output.txt
+    @echo "Cargo tests passed!"
+    @rm -f cargo_output.txt npm_output.txt
+
+# Run npm analysis and duplicate tests
+test-npm: build
+    @echo "Running npm analysis tests..."
+    @CLICOLOR_FORCE=1 {{binary}} analyze test_suite/npm_duplicates --unused
+    @{{binary}} analyze test_suite/npm_duplicates --unused > npm_output.txt
+    @grep -q "Potentially Unused Dependencies" npm_output.txt
+    @echo "\nRunning npm duplicate tests..."
+    @CLICOLOR_FORCE=1 {{binary}} duplicates test_suite/npm_duplicates --verbose
+    @{{binary}} duplicates test_suite/npm_duplicates --verbose > npm_output.txt
+    @grep -q "lodash (2 versions)" npm_output.txt
+    @grep -q "v4.17.21 (2 transitive)" npm_output.txt
+    @grep -q "v4.17.20 (4 transitive)" npm_output.txt
+    @echo "NPM tests passed!"
+    @rm -f cargo_output.txt npm_output.txt
+
+# Format all files under src/
+fmt:
+    cargo fmt --all
+
+# Clean build artifacts
+clean:
+    rm -f cargo_output.txt npm_output.txt
+    cargo clean

--- a/Justfile
+++ b/Justfile
@@ -14,28 +14,26 @@ test: test-cargo test-npm
 # Run Cargo duplicate tests
 test-cargo: build
     @echo "Running Cargo duplicate tests..."
-    @CLICOLOR_FORCE=1 {{binary}} duplicates test_suite/cargo_duplicates --verbose
-    @{{binary}} duplicates test_suite/cargo_duplicates --verbose > cargo_output.txt
+    @CLICOLOR_FORCE=1 {{ binary }} duplicates test_suite/cargo_duplicates --verbose
+    @{{ binary }} duplicates test_suite/cargo_duplicates --verbose > cargo_output.txt
     @grep -q "serde (2 versions)" cargo_output.txt
     @grep -q "v1.0.152 (2 transitive)" cargo_output.txt
     @grep -q "v1.0.150 (4 transitive)" cargo_output.txt
     @echo "Cargo tests passed!"
-    @rm -f cargo_output.txt npm_output.txt
 
 # Run npm analysis and duplicate tests
 test-npm: build
     @echo "Running npm analysis tests..."
-    @CLICOLOR_FORCE=1 {{binary}} analyze test_suite/npm_duplicates --unused
-    @{{binary}} analyze test_suite/npm_duplicates --unused > npm_output.txt
+    @CLICOLOR_FORCE=1 {{ binary }} analyze test_suite/npm_duplicates --unused
+    @{{ binary }} analyze test_suite/npm_duplicates --unused > npm_output.txt
     @grep -q "Potentially Unused Dependencies" npm_output.txt
     @echo "\nRunning npm duplicate tests..."
-    @CLICOLOR_FORCE=1 {{binary}} duplicates test_suite/npm_duplicates --verbose
-    @{{binary}} duplicates test_suite/npm_duplicates --verbose > npm_output.txt
+    @CLICOLOR_FORCE=1 {{ binary }} duplicates test_suite/npm_duplicates --verbose
+    @{{ binary }} duplicates test_suite/npm_duplicates --verbose > npm_output.txt
     @grep -q "lodash (2 versions)" npm_output.txt
     @grep -q "v4.17.21 (2 transitive)" npm_output.txt
     @grep -q "v4.17.20 (4 transitive)" npm_output.txt
     @echo "NPM tests passed!"
-    @rm -f cargo_output.txt npm_output.txt
 
 # Format all files under src/
 fmt:

--- a/src/analyzer/extractor.rs
+++ b/src/analyzer/extractor.rs
@@ -242,8 +242,14 @@ import sub from '@scope/package/subpath';
 "#;
         let imports = extract_imports(source);
         assert_eq!(imports.len(), 2);
-        assert_eq!(imports[0].resolved_package, Some("@scope/package".to_string()));
-        assert_eq!(imports[1].resolved_package, Some("@scope/package".to_string()));
+        assert_eq!(
+            imports[0].resolved_package,
+            Some("@scope/package".to_string())
+        );
+        assert_eq!(
+            imports[1].resolved_package,
+            Some("@scope/package".to_string())
+        );
     }
 
     #[test]

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -47,7 +47,9 @@ impl ImportAnalyzer {
             .build();
 
         for entry in walker {
-            let entry = entry.into_diagnostic().context("Failed to read directory entry")?;
+            let entry = entry
+                .into_diagnostic()
+                .context("Failed to read directory entry")?;
             let path = entry.path();
 
             if !path.is_file() {
@@ -93,7 +95,10 @@ fn is_js_ts_file(path: &Path) -> bool {
         return false;
     };
 
-    matches!(ext, "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts")
+    matches!(
+        ext,
+        "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" | "mts" | "cts"
+    )
 }
 
 /// Check if a file is likely a test file
@@ -201,10 +206,7 @@ mod tests {
 
     #[test]
     fn test_extract_package_name() {
-        assert_eq!(
-            extract_package_name("lodash"),
-            Some("lodash".to_string())
-        );
+        assert_eq!(extract_package_name("lodash"), Some("lodash".to_string()));
         assert_eq!(
             extract_package_name("lodash/fp"),
             Some("lodash".to_string())

--- a/src/duplicates.rs
+++ b/src/duplicates.rs
@@ -123,7 +123,7 @@ fn calculate_transitive_dependents(
     use std::collections::{HashSet, VecDeque};
 
     // First, we need a way to look up a package by its name@version key
-    // We can build this map once if we want to optimize, but for now we'll search
+    // We can build this map once if we want to optimize, but we'll search
     let mut reverse_graph: std::collections::HashMap<String, &Vec<String>> =
         std::collections::HashMap::new();
     for (name, versions) in packages_by_name {

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -48,7 +48,11 @@ impl DependencyGraph {
     }
 
     /// Analyze which packages are used vs unused
-    pub fn analyze_usage(&self, used_packages: &HashSet<String>, include_dev: bool) -> UsageAnalysis {
+    pub fn analyze_usage(
+        &self,
+        used_packages: &HashSet<String>,
+        include_dev: bool,
+    ) -> UsageAnalysis {
         let mut used = Vec::new();
         let mut unused = Vec::new();
         let mut expected_unused = Vec::new();
@@ -144,9 +148,7 @@ impl DependencyGraph {
 
         let is_dev_path = chains.iter().any(|chain| {
             chain.first().map_or(false, |root| {
-                self.packages
-                    .get(root)
-                    .map_or(false, |p| p.is_dev)
+                self.packages.get(root).map_or(false, |p| p.is_dev)
             })
         });
 
@@ -163,7 +165,11 @@ impl DependencyGraph {
         let target_name = &self.graph[target];
 
         // If it's a direct dependency, return a single-element chain
-        if self.packages.get(target_name).map_or(false, |p| p.is_direct) {
+        if self
+            .packages
+            .get(target_name)
+            .map_or(false, |p| p.is_direct)
+        {
             return vec![vec![target_name.clone()]];
         }
 
@@ -188,7 +194,11 @@ impl DependencyGraph {
                 new_path.extend(path.clone());
 
                 // If this is a direct dependency, we found a complete chain
-                if self.packages.get(neighbor_name).map_or(false, |p| p.is_direct) {
+                if self
+                    .packages
+                    .get(neighbor_name)
+                    .map_or(false, |p| p.is_direct)
+                {
                     if !visited_paths.contains(&new_path) {
                         visited_paths.insert(new_path.clone());
                         chains.push(new_path);
@@ -376,14 +386,10 @@ mod tests {
 
         packages.insert(
             "body-parser".to_string(),
-            Package::new("body-parser", "1.20.0")
-                .with_dependencies(vec!["raw-body".to_string()]),
+            Package::new("body-parser", "1.20.0").with_dependencies(vec!["raw-body".to_string()]),
         );
 
-        packages.insert(
-            "raw-body".to_string(),
-            Package::new("raw-body", "2.5.0"),
-        );
+        packages.insert("raw-body".to_string(), Package::new("raw-body", "2.5.0"));
 
         packages.insert(
             "unused-pkg".to_string(),

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -147,8 +147,8 @@ impl DependencyGraph {
         let chains = self.find_dependency_chains(*pkg_idx);
 
         let is_dev_path = chains.iter().any(|chain| {
-            chain.first().map_or(false, |root| {
-                self.packages.get(root).map_or(false, |p| p.is_dev)
+            chain.first().is_some_and(|root| {
+                self.packages.get(root).is_some_and(|p| p.is_dev)
             })
         });
 
@@ -168,7 +168,7 @@ impl DependencyGraph {
         if self
             .packages
             .get(target_name)
-            .map_or(false, |p| p.is_direct)
+            .is_some_and(|p| p.is_direct)
         {
             return vec![vec![target_name.clone()]];
         }
@@ -197,7 +197,7 @@ impl DependencyGraph {
                 if self
                     .packages
                     .get(neighbor_name)
-                    .map_or(false, |p| p.is_direct)
+                    .is_some_and(|p| p.is_direct)
                 {
                     if !visited_paths.contains(&new_path) {
                         visited_paths.insert(new_path.clone());

--- a/src/lockfile/cargo.rs
+++ b/src/lockfile/cargo.rs
@@ -37,13 +37,11 @@ impl<'a> CargoLockfileParser<'a> {
     }
 
     pub fn parse(&self) -> Result<HashMap<String, Package>> {
-        let content = fs::read_to_string(self.lockfile_path).map_err(|e| {
-            miette::miette!("Failed to read Cargo.lock: {}", e)
-        })?;
+        let content = fs::read_to_string(self.lockfile_path)
+            .map_err(|e| miette::miette!("Failed to read Cargo.lock: {}", e))?;
 
-        let lockfile: CargoLockfile = toml::from_str(&content).map_err(|e| {
-            miette::miette!("Failed to parse Cargo.lock: {}", e)
-        })?;
+        let lockfile: CargoLockfile = toml::from_str(&content)
+            .map_err(|e| miette::miette!("Failed to parse Cargo.lock: {}", e))?;
 
         self.build_package_map(&lockfile)
     }
@@ -57,7 +55,8 @@ impl<'a> CargoLockfileParser<'a> {
             let key = format!("{}@{}", pkg.name, pkg.version);
 
             // Parse dependencies - they come as "name version" strings
-            let deps: Vec<String> = pkg.dependencies
+            let deps: Vec<String> = pkg
+                .dependencies
                 .as_ref()
                 .map(|deps| {
                     deps.iter()
@@ -74,8 +73,7 @@ impl<'a> CargoLockfileParser<'a> {
                 })
                 .unwrap_or_default();
 
-            let package = Package::new(&pkg.name, &pkg.version)
-                .with_dependencies(deps);
+            let package = Package::new(&pkg.name, &pkg.version).with_dependencies(deps);
 
             // Mark path dependencies (no source) as "direct" for now
             // In Cargo, the root crate has no source field
@@ -94,13 +92,11 @@ impl<'a> CargoLockfileParser<'a> {
     /// Parse and return raw package data for duplicate analysis
     /// Returns a map of package name -> list of (version, dependents)
     pub fn parse_for_duplicates(&self) -> Result<HashMap<String, Vec<CargoPackageInfo>>> {
-        let content = fs::read_to_string(self.lockfile_path).map_err(|e| {
-            miette::miette!("Failed to read Cargo.lock: {}", e)
-        })?;
+        let content = fs::read_to_string(self.lockfile_path)
+            .map_err(|e| miette::miette!("Failed to read Cargo.lock: {}", e))?;
 
-        let lockfile: CargoLockfile = toml::from_str(&content).map_err(|e| {
-            miette::miette!("Failed to parse Cargo.lock: {}", e)
-        })?;
+        let lockfile: CargoLockfile = toml::from_str(&content)
+            .map_err(|e| miette::miette!("Failed to parse Cargo.lock: {}", e))?;
 
         let mut by_name: HashMap<String, Vec<CargoPackageInfo>> = HashMap::new();
 
@@ -117,10 +113,9 @@ impl<'a> CargoLockfileParser<'a> {
                         parts[0].to_string()
                     };
 
-                    dependents
-                        .entry(dep_key)
-                        .or_default()
-                        .push(pkg.name.clone());
+                    let pkg_key = format!("{}@{}", pkg.name, pkg.version);
+
+                    dependents.entry(dep_key).or_default().push(pkg_key);
                 }
             }
         }

--- a/src/lockfile/mod.rs
+++ b/src/lockfile/mod.rs
@@ -8,7 +8,7 @@ use miette::{bail, Result};
 
 use crate::types::Package;
 
-pub use cargo::CargoLockfileParser;
+pub use cargo::{CargoLockfileParser, CargoPackageInfo};
 pub use npm::NpmLockfileParser;
 
 /// Unified lockfile parser that auto-detects the lockfile type

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,11 @@ use crate::reporter::Reporter;
 
 #[derive(Parser)]
 #[command(name = "depx")]
-#[command(author, version, about = "Intelligent dependency analyzer for JS/TS projects")]
+#[command(
+    author,
+    version,
+    about = "Intelligent dependency analyzer for JS/TS projects"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -106,7 +110,11 @@ async fn main() -> Result<()> {
         Commands::Deprecated { path } => {
             run_deprecated(&path).await?;
         }
-        Commands::Duplicates { path, verbose, json } => {
+        Commands::Duplicates {
+            path,
+            verbose,
+            json,
+        } => {
             run_duplicates(&path, verbose, json).await?;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity, clippy::collapsible_match)]
+
 mod analyzer;
 mod duplicates;
 mod graph;
@@ -6,7 +8,7 @@ mod reporter;
 mod types;
 mod vulnerability;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 use miette::Result;
@@ -218,7 +220,7 @@ async fn run_deprecated(path: &PathBuf) -> Result<()> {
     Ok(())
 }
 
-async fn run_duplicates(path: &PathBuf, verbose: bool, json: bool) -> Result<()> {
+async fn run_duplicates(path: &Path, verbose: bool, json: bool) -> Result<()> {
     let reporter = if verbose {
         Reporter::new().verbose()
     } else {

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -71,10 +71,7 @@ impl Reporter {
 
         // Unused direct dependencies (truly removable)
         if !analysis.unused_direct.is_empty() {
-            println!(
-                "{}",
-                "Unused Dependencies (safe to remove):".red().bold()
-            );
+            println!("{}", "Unused Dependencies (safe to remove):".red().bold());
             for pkg in &analysis.unused_direct {
                 let dev_marker = if pkg.is_dev { " (dev)" } else { "" };
                 println!(
@@ -85,11 +82,7 @@ impl Reporter {
                 );
             }
             println!();
-            println!(
-                "  {} {}",
-                "Tip:".dimmed(),
-                "npm uninstall <package>".cyan()
-            );
+            println!("  {} {}", "Tip:".dimmed(), "npm uninstall <package>".cyan());
             println!();
         }
 
@@ -127,17 +120,11 @@ impl Reporter {
 
         // Unused transitive dependencies (verbose only)
         if self.verbose {
-            let unused_transitive: Vec<_> = analysis
-                .unused
-                .iter()
-                .filter(|p| !p.is_direct)
-                .collect();
+            let unused_transitive: Vec<_> =
+                analysis.unused.iter().filter(|p| !p.is_direct).collect();
 
             if !unused_transitive.is_empty() {
-                println!(
-                    "{}",
-                    "Unused Transitive Dependencies:".yellow().bold()
-                );
+                println!("{}", "Unused Transitive Dependencies:".yellow().bold());
                 for pkg in unused_transitive.iter().take(20) {
                     println!(
                         "  {} {}",
@@ -162,16 +149,16 @@ impl Reporter {
         println!();
 
         if analysis.unused_direct.is_empty() && analysis.unused.is_empty() {
-            println!(
-                "{}",
-                "All dependencies appear to be in use!".green().bold()
-            );
+            println!("{}", "All dependencies appear to be in use!".green().bold());
             return;
         }
 
         println!(
             "{}",
-            "Potentially Unused Dependencies".yellow().bold().underline()
+            "Potentially Unused Dependencies"
+                .yellow()
+                .bold()
+                .underline()
         );
         println!();
 
@@ -189,8 +176,7 @@ impl Reporter {
             println!();
             println!(
                 "{}",
-                "Tip: Run `npm uninstall <package>` to remove unused packages"
-                    .dimmed()
+                "Tip: Run `npm uninstall <package>` to remove unused packages".dimmed()
             );
         }
 
@@ -198,7 +184,7 @@ impl Reporter {
     }
 
     /// Report why a package is installed
-    pub fn report_why(&self, package_name: &str, explanation: &PackageExplanation) {
+    pub fn report_why(&self, _package_name: &str, explanation: &PackageExplanation) {
         println!();
         println!(
             "{} {}@{}",
@@ -252,10 +238,7 @@ impl Reporter {
         println!();
 
         if vulnerabilities.is_empty() {
-            println!(
-                "{}",
-                "No known vulnerabilities found!".green().bold()
-            );
+            println!("{}", "No known vulnerabilities found!".green().bold());
             return;
         }
 
@@ -335,10 +318,7 @@ impl Reporter {
         println!();
 
         if deprecated.is_empty() {
-            println!(
-                "{}",
-                "No deprecated packages found!".green().bold()
-            );
+            println!("{}", "No deprecated packages found!".green().bold());
             return;
         }
 
@@ -378,17 +358,11 @@ impl Reporter {
         println!();
 
         if analysis.duplicates.is_empty() {
-            println!(
-                "{}",
-                "No duplicate dependencies found!".green().bold()
-            );
+            println!("{}", "No duplicate dependencies found!".green().bold());
             return;
         }
 
-        println!(
-            "{}",
-            "Duplicate Dependencies Analysis".bold().underline()
-        );
+        println!("{}", "Duplicate Dependencies Analysis".bold().underline());
         println!();
 
         // Summary
@@ -512,9 +486,16 @@ impl Reporter {
                 )
             };
 
+            let transitive_str = if version.transitive_count > 0 {
+                format!("({} transitive)", version.transitive_count)
+            } else {
+                "".to_string()
+            };
+
             println!(
-                "      {} {}",
+                "      {} {}{}",
                 format!("v{}", version.version).white(),
+                transitive_str.yellow(),
                 dependents_str.dimmed()
             );
         }

--- a/src/vulnerability/mod.rs
+++ b/src/vulnerability/mod.rs
@@ -23,7 +23,7 @@ pub async fn check_vulnerabilities(
 
     // Convert to vec for batching
     let packages_vec: Vec<(&String, &Package)> = packages.iter().collect();
-    let total_batches = (total_packages + BATCH_SIZE - 1) / BATCH_SIZE;
+    let total_batches = total_packages.div_ceil(BATCH_SIZE);
 
     // Show progress for large projects
     if total_packages > BATCH_SIZE {
@@ -228,7 +228,7 @@ pub async fn check_deprecated(
 ) -> Result<Vec<DeprecatedPackage>> {
     let mut deprecated = Vec::new();
 
-    for (_name, pkg) in packages {
+    for pkg in packages.values() {
         if let Some(ref message) = pkg.deprecated {
             deprecated.push(DeprecatedPackage {
                 package: pkg.clone(),

--- a/src/vulnerability/mod.rs
+++ b/src/vulnerability/mod.rs
@@ -223,7 +223,9 @@ async fn fetch_single_vulnerability(
 }
 
 /// Check for deprecated packages
-pub async fn check_deprecated(packages: &HashMap<String, Package>) -> Result<Vec<DeprecatedPackage>> {
+pub async fn check_deprecated(
+    packages: &HashMap<String, Package>,
+) -> Result<Vec<DeprecatedPackage>> {
     let mut deprecated = Vec::new();
 
     for (_name, pkg) in packages {
@@ -241,7 +243,11 @@ pub async fn check_deprecated(packages: &HashMap<String, Package>) -> Result<Vec
     Ok(deprecated)
 }
 
-fn convert_osv_vuln(osv: &OsvVulnerability, package_name: &str, version: &str) -> Option<Vulnerability> {
+fn convert_osv_vuln(
+    osv: &OsvVulnerability,
+    package_name: &str,
+    version: &str,
+) -> Option<Vulnerability> {
     // Determine severity from CVSS score or database_specific
     let severity = determine_severity(osv);
 
@@ -261,7 +267,10 @@ fn convert_osv_vuln(osv: &OsvVulnerability, package_name: &str, version: &str) -
 
     Some(Vulnerability {
         id: osv.id.clone(),
-        title: osv.summary.clone().unwrap_or_else(|| "Unknown vulnerability".to_string()),
+        title: osv
+            .summary
+            .clone()
+            .unwrap_or_else(|| "Unknown vulnerability".to_string()),
         severity,
         package_name: package_name.to_string(),
         vulnerable_range,

--- a/test_suite/cargo_duplicates/Cargo.lock
+++ b/test_suite/cargo_duplicates/Cargo.lock
@@ -1,0 +1,43 @@
+[[package]]
+name = "depx"
+version = "0.3.0"
+dependencies = [
+ "pkg-a 1.0.0",
+ "pkg-d 1.0.0",
+]
+
+[[package]]
+name = "pkg-a"
+version = "1.0.0"
+dependencies = [
+ "pkg-b 1.0.0",
+]
+
+[[package]]
+name = "pkg-b"
+version = "1.0.0"
+dependencies = [
+ "pkg-c 1.0.0",
+]
+
+[[package]]
+name = "pkg-c"
+version = "1.0.0"
+dependencies = [
+ "serde 1.0.150",
+]
+
+[[package]]
+name = "pkg-d"
+version = "1.0.0"
+dependencies = [
+ "serde 1.0.152",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.150"
+
+[[package]]
+name = "serde"
+version = "1.0.152"

--- a/test_suite/npm_duplicates/package.json
+++ b/test_suite/npm_duplicates/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "npm-test",
+  "dependencies": {
+    "pkg-a": "1.0.0",
+    "pkg-b": "1.0.0"
+  }
+}


### PR DESCRIPTION
Yo, ive been looking on the project and wanted to contribute, i first added a test suite that contains lock files so depx can be tested with mocks. I added a justFile which is a variant of make but with slightly easier syntax. The JustFile contains few commands:
-  just test: test **ONLY** the mocks located in test_suite/
- just fmt: format the code with cargo fmt --all
- just clean: delete tests output and debug builds from target folder
- just build: useless since we can write it with cargo build

source code changes:

1. Transitive dependencies detection:
search with a BFS engine to trace unique dependents all the way to the root.
Improved Metrics by adding `transitive_count` to `DuplicateVersion` `extra_compile_units` to `DuplicateStats`.
I made the architecture more "generic" by making the analysis into a generic one so Cargo and npm share the same impact/severity calculation/

2.NPM
I added support for npm v3 and root context to make the parsing stronger

3.CARGO
I added versionned keys, after reviewing it is quite useless so we can delete that (Cargo detects duplicates crates)

4.UI
Added transitive to report transitive dependencies (e.g (
LOW SEVERITY
  - lodash (2 versions)
      v4.17.20 (4 transitive)← pkg-3@1.0.0
      v4.17.21 (2 transitive)← pkg-4@1.0.0
      → Update pkg-3@1.0.0 to use lodash 4.17.21
))

5.CLIPPY

I didnt fixed all the warnings (mainly dead_code) but i changed a `&PathBuf` param to `&Path` (Path is slice of PathBuf so it is slightly lighter than a complete PathBuf)